### PR TITLE
Adding egcs 1.1.2 aka gcc 2.91.66

### DIFF
--- a/gcc-2.91.66.Dockerfile
+++ b/gcc-2.91.66.Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:focal as build
+RUN apt-get update
+RUN apt-get install -y build-essential bison file gperf gcc gcc-multilib git wget
+
+ARG VERSION=2.91.66
+ENV VERSION=${VERSION}
+
+WORKDIR /work
+RUN wget https://gcc.gnu.org/pub/gcc/old-releases/egcs/egcs-1.1.2.tar.bz2
+RUN mkdir -p /work/gcc-${VERSION}/
+RUN tar xjf egcs-1.1.2.tar.bz2 --strip-components=1 -C gcc-${VERSION}
+
+WORKDIR /work/gcc-${VERSION}/
+RUN for dir in libiberty gcc; do \
+    cd /work/gcc-${VERSION}/${dir}; \
+    ./configure \
+        --target=mips-linux-gnu \
+        --prefix=/opt/cross \
+        --with-endian-little \
+        --with-gnu-as \
+        --disable-gprof \
+        --disable-gdb \
+        --disable-werror \
+        --host=i386-pc-linux \
+        --build=i386-pc-linux; \
+    done
+
+COPY patches /work/patches
+
+RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' **/*.c
+RUN patch -u -p1 gcc/obstack.h -i ../patches/obstack-${VERSION}.h.patch
+
+RUN make -C libiberty/ CFLAGS="-std=gnu89 -m32 -static"
+RUN make -C gcc/ -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
+
+RUN test -f gcc/cc1
+RUN file gcc/cc1
+
+### STAGE 2
+
+FROM ubuntu:focal as base
+
+ARG VERSION=2.91.66
+ENV VERSION=${VERSION}
+
+RUN mkdir -p /work/gcc-${VERSION}/
+
+COPY --from=build /work/gcc-${VERSION}/gcc/cpp /work/gcc-${VERSION}/
+COPY --from=build /work/gcc-${VERSION}/gcc/cc1 /work/gcc-${VERSION}/
+COPY --from=build /work/gcc-${VERSION}/gcc/xgcc /work/gcc-${VERSION}/
+COPY --from=build /work/gcc-${VERSION}/gcc/cc1plus /work/gcc-${VERSION}/
+COPY --from=build /work/gcc-${VERSION}/gcc/g++ /work/gcc-${VERSION}/
+
+COPY entrypoint.sh /work/
+RUN chmod +x /work/entrypoint.sh
+CMD [ "/work/entrypoint.sh" ]

--- a/patches/obstack-2.91.66.h.patch
+++ b/patches/obstack-2.91.66.h.patch
@@ -1,0 +1,12 @@
+--- obstack.h	1998-05-05 23:17:18.000000000 +0000
++++ obstack_patched.h	2023-08-14 20:03:25.162798764 +0000
+@@ -417,7 +417,8 @@
+ ({ struct obstack *__o = (OBSTACK);					\
+    if (__o->next_free + sizeof (void *) > __o->chunk_limit)		\
+      _obstack_newchunk (__o, sizeof (void *));				\
+-   *((void **)__o->next_free)++ = ((void *)datum);			\
++   *((void **)__o->next_free) = ((void *)datum);			\
++   __o->next_free += sizeof (void *);	\
+    (void) 0; })
+ 
+ # define obstack_int_grow(OBSTACK,datum)				\


### PR DESCRIPTION
```
mark@carbon:~/github/old-gcc$ ./build-gcc-2.91.66/cc1 -version </dev/null
GNU C version egcs-2.91.66 19990314 (egcs-1.1.2 release) (mips-linux-gnu) compiled by GNU C version 9.4.0.
options passed: 
options enabled:  -fpeephole -ffunction-cse -fkeep-static-consts
 -fpcc-struct-return -fcommon -fgnu-linker -fargument-alias -mgas -meb
 -mcpu=3000
	.file	1 "stdin"
gcc2_compiled.:
__gnu_compiled_c:
```