### PR TITLE
Fix g++/cc1plus on gcc 2.6.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-ifndef VERSION
-$(error You must specify a VERSION e.g. VERSION=2.8.1)
-endif
-
-all:
+all: check-version
 	mkdir -p build-gcc-$(VERSION)
 	docker compose up --build && docker compose down
 
 clean:
 	rm -rf build-gcc-*/
 
-.PHONY: all
+check-version:
+ifndef VERSION
+	$(error You must specify a VERSION e.g. VERSION=2.8.1)
+endif
+
+.PHONY: all check-version

--- a/gcc-2.6.3-psx.Dockerfile
+++ b/gcc-2.6.3-psx.Dockerfile
@@ -13,7 +13,10 @@ RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' *.c
 
 RUN patch -u -p1 obstack.h -i ../patches/obstack-2.7.2.h.patch
 RUN patch -u -p1 sdbout.c -i ../patches/sdbout-2.6.3.c.patch
+RUN patch -u -p1 cp/g++.c -i ../patches/g++-2.6.3.c.patch
 RUN patch -su -p1 < ../patches/psx.patch
+
+RUN touch -c cp/parse.y cp/parse.h cp/parse.c
 
 RUN ./configure \
     --target=mips-sony-psx \
@@ -23,7 +26,7 @@ RUN ./configure \
     --host=i386-pc-linux \
     --build=i386-pc-linux
 
-RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static -Dbsd4_4 -Dmips -march=i686" || true
+RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static -Dbsd4_4 -Dmips -march=i686 -DHAVE_STRERROR"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s

--- a/gcc-2.6.3.Dockerfile
+++ b/gcc-2.6.3.Dockerfile
@@ -13,7 +13,10 @@ RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' *.c
 
 RUN patch -u -p1 obstack.h -i ../patches/obstack-2.7.2.h.patch
 RUN patch -u -p1 sdbout.c -i ../patches/sdbout-2.6.3.c.patch
+RUN patch -u -p1 cp/g++.c -i ../patches/g++-2.6.3.c.patch
 RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.6.patch
+
+RUN touch -c cp/parse.y cp/parse.h cp/parse.c
 
 RUN ./configure \
     --target=mips-linux-gnu \
@@ -23,7 +26,8 @@ RUN ./configure \
     --host=i386-pc-linux \
     --build=i386-pc-linux
 
-RUN make cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static -Dbsd4_4 -Dmips" || true
+
+RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static -Dbsd4_4 -Dmips -DHAVE_STRERROR"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s

--- a/patches/g++-2.6.3.c.patch
+++ b/patches/g++-2.6.3.c.patch
@@ -1,0 +1,51 @@
+--- cp/g++.c	1994-10-29 11:17:44.000000000 +0000
++++ cp/g++-patched.c	2023-10-08 08:48:51.000932344 +0000
+@@ -83,12 +83,16 @@
+ extern int errno;
+ #endif
+ 
++#ifndef HAVE_STRERROR
+ extern int sys_nerr;
+ #if defined(bsd4_4) || defined(__NetBSD__)
+ extern const char *const sys_errlist[];
+ #else
+ extern char *sys_errlist[];
+ #endif
++#else /* HAVE_STERRROR */
++char *strerror ();
++#endif
+ 
+ /* Name with which this program was invoked.  */
+ static char *programname;
+@@ -209,10 +213,14 @@
+ {
+   char *s;
+ 
++#ifndef HAVE_STRERROR
+   if (errno < sys_nerr)
+     s = concat ("%s: ", sys_errlist[errno], "");
+   else
+     s = "cannot open %s";
++#else
++  s = strerror (errno);
++#endif
+   fatal (s, name);
+ }
+ 
+@@ -281,11 +289,14 @@
+ {
+   char *s;
+ 
++#ifndef HAVE_STRERROR
+   if (errno < sys_nerr)
+-    s = concat ("installation problem, cannot exec %s: ",
+-		sys_errlist[errno], "");
++    s = concat ("installation problem, cannot exec %s: ", sys_errlist[errno], "");
+   else
+     s = "installation problem, cannot exec %s";
++#else
++  s = strerror (errno);
++#endif
+   error (s, name);
+ }
+ 


### PR DESCRIPTION
Fixes #14.

Note that we `touch` the `cp/parse.c` file because it is *older* than the cp/parse.h and cp/parse.y and so the Makefile wants to run `bison` - but this isnt necessary (and modern bison is more strict and throws errors!)