### PR TITLE
Add support for __attribute__((section(".data")))

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Run `VERSION=2.7.2.2 make` to build an old version of GCC.
 Alternatively use one of the prebuild binaries available from the [Releases](https://github.com/decompals/old-gcc/releases) page.
 
 **Currently supported versions:**
+- GCC 2.5.7
 - GCC 2.6.0
 - GCC 2.6.3
 - GCC 2.7.0

--- a/gcc-2.5.7.Dockerfile
+++ b/gcc-2.5.7.Dockerfile
@@ -18,7 +18,7 @@ RUN patch -u -p1 collect2.c -i ../patches/collect2-2.6.0.c.patch
 RUN patch -u -p1 cccp.c -i ../patches/cccp-2.5.7.c.patch
 RUN patch -u -p1 gcc.c -i ../patches/gcc-2.5.7.c.patch
 RUN patch -u -p1 g++.c -i ../patches/g++-2.5.7.c.patch
-RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.6.patch
+RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.5.patch
 
 RUN ./configure \
     --target=mips-linux-gnu \

--- a/gcc-2.6.0.Dockerfile
+++ b/gcc-2.6.0.Dockerfile
@@ -31,6 +31,7 @@ RUN make cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static -Dbsd4_4 -Dmip
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.6.3-psx.Dockerfile
+++ b/gcc-2.6.3-psx.Dockerfile
@@ -30,6 +30,7 @@ RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static -Dbsd4_4 -D
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/ || true

--- a/gcc-2.6.3.Dockerfile
+++ b/gcc-2.6.3.Dockerfile
@@ -31,6 +31,7 @@ RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static -Dbsd4_4 -D
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/ || true

--- a/gcc-2.7.0.Dockerfile
+++ b/gcc-2.7.0.Dockerfile
@@ -31,6 +31,7 @@ RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.7.1.Dockerfile
+++ b/gcc-2.7.1.Dockerfile
@@ -31,6 +31,7 @@ RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.7.2.1.Dockerfile
+++ b/gcc-2.7.2.1.Dockerfile
@@ -34,6 +34,7 @@ RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.7.2.2.Dockerfile
+++ b/gcc-2.7.2.2.Dockerfile
@@ -34,6 +34,7 @@ RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.7.2.3.Dockerfile
+++ b/gcc-2.7.2.3.Dockerfile
@@ -32,6 +32,7 @@ RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.7.2.Dockerfile
+++ b/gcc-2.7.2.Dockerfile
@@ -34,6 +34,7 @@ RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.8.0.Dockerfile
+++ b/gcc-2.8.0.Dockerfile
@@ -26,12 +26,13 @@ COPY patches /work/patches
 RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' *.c
 RUN patch -u -p1 obstack.h -i ../patches/obstack-2.8.0.h.patch
 
-RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.7.patch
+RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.8.patch
 
 RUN make cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.8.1.Dockerfile
+++ b/gcc-2.8.1.Dockerfile
@@ -26,12 +26,13 @@ COPY patches /work/patches
 RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' *.c
 RUN patch -u -p1 obstack.h -i ../patches/obstack-2.8.1.h.patch
 
-RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.7.patch
+RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.8.patch
 
 RUN make -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.91.66.Dockerfile
+++ b/gcc-2.91.66.Dockerfile
@@ -30,13 +30,14 @@ COPY patches /work/patches
 
 RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' **/*.c
 RUN patch -u -p1 gcc/obstack.h -i ../patches/obstack-${VERSION}.h.patch
-RUN patch -u -p1 gcc/config/mips/mips.h -i ../patches/mipsel-2.7.patch
+RUN patch -u -p1 gcc/config/mips/mips.h -i ../patches/mipsel-2.8.patch
 
 RUN make -C libiberty/ CFLAGS="-std=gnu89 -m32 -static"
 RUN make -C gcc/ -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./gcc/cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./gcc/cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv ./gcc/xgcc ./gcc/gcc
 RUN mkdir /build && cp ./gcc/cpp ./gcc/cc1 ./gcc/gcc ./gcc/cc1plus ./gcc/g++ /build/

--- a/gcc-2.95.2.Dockerfile
+++ b/gcc-2.95.2.Dockerfile
@@ -30,13 +30,14 @@ COPY patches /work/patches
 
 RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' **/*.c
 RUN patch -u -p1 include/obstack.h -i ../patches/obstack-${VERSION}.h.patch
-RUN patch -u -p1 gcc/config/mips/mips.h -i ../patches/mipsel-2.7.patch
+RUN patch -u -p1 gcc/config/mips/mips.h -i ../patches/mipsel-2.8.patch
 
 RUN make -C libiberty/ CFLAGS="-std=gnu89 -m32 -static"
 RUN make -C gcc/ -j cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
 
 COPY tests /work/tests
 RUN ./gcc/cc1 -mel -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./gcc/cc1 -quiet -O2 /work/tests/section_attribute.c
 
 RUN mv ./gcc/xgcc ./gcc/gcc
 RUN mkdir /build && cp ./gcc/cpp ./gcc/cc1 ./gcc/gcc ./gcc/cc1plus ./gcc/g++ /build/

--- a/patches/mipsel-2.5.patch
+++ b/patches/mipsel-2.5.patch
@@ -1,6 +1,6 @@
---- config/mips/mips.h	1994-07-11 18:22:16.000000000 +0000
-+++ config/mips/mips-patched.h	2023-11-14 20:32:41.282369333 +0000
-@@ -544,8 +544,8 @@
+--- config/mips/mips.h	1993-11-15 06:54:12.000000000 +0000
++++ config/mips/mips-patched.h	2023-11-14 22:48:19.932635363 +0000
+@@ -545,8 +545,8 @@
  /* Names to predefine in the preprocessor for this target machine.  */
 
  #ifndef CPP_PREDEFINES
@@ -11,7 +11,7 @@
  -Asystem(unix) -Asystem(bsd) -Acpu(mips) -Amachine(mips)"
  #endif
 
-@@ -901,6 +901,11 @@
+@@ -881,6 +881,11 @@
  */
  #define BITS_BIG_ENDIAN 0
 
@@ -23,14 +23,3 @@
  /* Define this if most significant byte of a word is the lowest numbered. */
  #ifndef BYTES_BIG_ENDIAN
  #ifndef DECSTATION
-@@ -3678,3 +3683,10 @@
- #define NO_BUILTIN_PTRDIFF_TYPE
- #define PTRDIFF_TYPE (TARGET_LONG64 ? "long int" : "int")
- #endif
-+
-+/* Assemble generic sections.
-+   This is currently only used to support section attributes.  */
-+
-+#define ASM_OUTPUT_SECTION_NAME(FILE, NAME) \
-+   do { fprintf (FILE, ".section\t\"%s\"\n", NAME); } while (0)
-+

--- a/patches/mipsel-2.8.patch
+++ b/patches/mipsel-2.8.patch
@@ -1,6 +1,6 @@
---- config/mips/mips.h	1995-06-15 19:32:41.000000000 +0000
-+++ config/mips/mips-patched.h	2023-11-14 22:31:00.506591160 +0000
-@@ -406,6 +406,9 @@
+--- config/mips/mips.h	1997-12-29 00:34:57.000000000 +0000
++++ config/mips/mips-patched.h	2023-11-14 22:29:18.785172634 +0000
+@@ -441,6 +441,9 @@
  			   | TARGET_ENDIAN_DEFAULT)}			\
  }
  
@@ -10,7 +10,7 @@
  /* Default target_flags if no switches are specified  */
  
  #ifndef TARGET_DEFAULT
-@@ -954,6 +957,22 @@
+@@ -1153,6 +1156,22 @@
  #define ASM_OUTPUT_DESTRUCTOR(file, name)
  
  #endif /* 0 */
@@ -20,12 +20,12 @@
 +   NULL_TREE.  Some target formats do not support arbitrary sections.  Do not
 +   define this macro in such cases.  */
 +
-+#define ASM_OUTPUT_SECTION_NAME(F, DECL, NAME) \
++#define ASM_OUTPUT_SECTION_NAME(F, DECL, NAME, RELOC) \
 +do {								\
 +  extern FILE *asm_out_text_file;				\
 +  if ((DECL) && TREE_CODE (DECL) == FUNCTION_DECL)		\
 +    fprintf (asm_out_text_file, "\t.section %s,\"ax\",@progbits\n", (NAME)); \
-+  else if ((DECL) && TREE_READONLY (DECL))			\
++  else if ((DECL) && DECL_READONLY_SECTION (DECL, RELOC))	\
 +    fprintf (F, "\t.section %s,\"a\",@progbits\n", (NAME));	\
 +  else								\
 +    fprintf (F, "\t.section %s,\"aw\",@progbits\n", (NAME));	\

--- a/tests/section_attribute.c
+++ b/tests/section_attribute.c
@@ -1,0 +1,1 @@
+int some_var __attribute__((section(".data"))) = 100;


### PR DESCRIPTION
GCC 2.5.7 doesn't support the __attribute(section(...)) functionality so I haven't tried to hack it in. It's been added to all other compilers.

Closes #6.