### PR TITLE
Add more -psx flavoured builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,19 +17,24 @@ jobs:
           - 2.5.7
           - 2.5.7-psx
           - 2.6.0
+          - 2.6.0-psx
           - 2.6.3
           - 2.6.3-psx
           - 2.7.0
           - 2.7.1
           - 2.7.2
+          - 2.7.2-psx
           - 2.7.2.1
           - 2.7.2.2
           - 2.7.2.3
           - 2.8.0
+          - 2.8.0-psx
           - 2.8.1
           - 2.8.1-psx
           - 2.91.66
+          - 2.91.66-psx
           - 2.95.2
+          - 2.95.2-psx
     name: Build GCC ${{ matrix.version }}
     steps:
       - name: Clone repository
@@ -42,12 +47,12 @@ jobs:
           cd build-gcc-${{ matrix.version }}
           tar -czvf ../gcc-${{ matrix.version }}.tar.gz *
       - name: Create artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gcc-${{ matrix.version }}
           path: gcc-${{ matrix.version }}.tar.gz
       - name: Publish release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |

--- a/gcc-2.6.0-psx.Dockerfile
+++ b/gcc-2.6.0-psx.Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:focal as build
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential gcc gcc-multilib wget
+
+WORKDIR /work
+RUN wget http://www.nic.funet.fi/index/gnu/funet/historical-funet-gnu-area-from-early-1990s/gcc-2.6.0.tar.gz
+RUN tar xzf gcc-2.6.0.tar.gz
+
+WORKDIR /work/gcc-2.6.0
+COPY patches /work/patches
+RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' *.c
+
+RUN patch -u -p1 obstack.h -i ../patches/obstack-2.7.2.h.patch
+RUN patch -u -p1 sdbout.c -i ../patches/sdbout-2.6.0.c.patch
+RUN patch -u -p1 collect2.c -i ../patches/collect2-2.6.0.c.patch
+RUN patch -u -p1 cccp.c -i ../patches/cccp-2.6.0.c.patch
+RUN patch -u -p1 gcc.c -i ../patches/gcc-2.6.0.c.patch
+RUN patch -u -p1 cp/g++.c -i ../patches/g++-2.6.0.c.patch
+RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.6.patch
+RUN patch -su -p1 < ../patches/psx.patch
+
+RUN ./configure \
+    --target=mips-linux-gnu \
+    --prefix=/opt/cross \
+    --with-endian-little \
+    --with-gnu-as \
+    --host=i386-pc-linux \
+    --build=i386-pc-linux
+
+RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static -Dbsd4_4 -Dmips -DHAVE_STRERROR"
+
+COPY tests /work/tests
+RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
+
+RUN mv xgcc gcc
+RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/
+
+FROM scratch AS export
+COPY --from=build /build/* .

--- a/gcc-2.7.2-psx.Dockerfile
+++ b/gcc-2.7.2-psx.Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:focal as build
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential gcc gcc-multilib wget
+
+ENV VERSION=2.7.2
+ENV GNUPATH=old-gnu
+
+WORKDIR /work
+RUN wget https://ftp.gnu.org/${GNUPATH}/gcc/gcc-${VERSION}.tar.gz
+RUN tar xzf gcc-${VERSION}.tar.gz
+
+WORKDIR /work/gcc-${VERSION}
+
+COPY patches /work/patches
+RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' *.c
+
+RUN patch -u -p1 obstack.h -i ../patches/obstack-2.7.2.h.patch
+RUN patch -u -p1 configure -i ../patches/configure.patch
+RUN patch -u -p1 config.sub -i ../patches/config.sub.patch
+RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.7.patch
+RUN patch -su -p1 < ../patches/psx.patch
+
+RUN ./configure \
+    --target=mips-sony-psx \
+    --prefix=/opt/cross \
+    --with-endian-little \
+    --with-gnu-as \
+    --disable-gprof \
+    --disable-gdb \
+    --disable-werror \
+    --host=i386-pc-linux \
+    --build=i386-pc-linux
+
+RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
+
+COPY tests /work/tests
+RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
+
+RUN mv xgcc gcc
+RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/
+
+FROM scratch AS export
+COPY --from=build /build/* .

--- a/gcc-2.8.0-psx.Dockerfile
+++ b/gcc-2.8.0-psx.Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:focal as build
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential gcc gcc-multilib wget
+
+ENV VERSION=2.8.0
+ENV GNUPATH=gnu
+
+WORKDIR /work
+RUN wget https://ftp.gnu.org/${GNUPATH}/gcc/gcc-${VERSION}.tar.gz
+RUN tar xzf gcc-${VERSION}.tar.gz
+
+WORKDIR /work/gcc-${VERSION}
+
+COPY patches /work/patches
+RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' *.c
+
+RUN patch -u -p1 obstack.h -i ../patches/obstack-2.8.0.h.patch
+RUN patch -u -p1 config/mips/mips.h -i ../patches/mipsel-2.8.patch
+RUN patch -su -p1 < ../patches/psx.patch
+
+RUN ./configure \
+    --target=mips-linux-gnu \
+    --prefix=/opt/cross \
+    --with-endian-little \
+    --with-gnu-as \
+    --disable-gprof \
+    --disable-gdb \
+    --disable-werror \
+    --host=i386-pc-linux \
+    --build=i386-pc-linux
+
+RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
+
+COPY tests /work/tests
+RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
+
+RUN mv xgcc gcc
+RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/
+
+FROM scratch AS export
+COPY --from=build /build/* .

--- a/gcc-2.91.66-psx.Dockerfile
+++ b/gcc-2.91.66-psx.Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:focal as build
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential gcc gcc-multilib wget
+
+ENV VERSION=2.91.66
+
+WORKDIR /work
+RUN wget https://gcc.gnu.org/pub/gcc/old-releases/egcs/egcs-1.1.2.tar.bz2
+RUN mkdir -p /work/gcc-${VERSION}/
+RUN tar xjf egcs-1.1.2.tar.bz2 --strip-components=1 -C gcc-${VERSION}
+
+WORKDIR /work/gcc-${VERSION}/
+
+COPY patches /work/patches
+
+RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' **/*.c
+RUN patch -u -p1 gcc/obstack.h -i ../patches/obstack-${VERSION}.h.patch
+RUN patch -u -p1 gcc/config/mips/mips.h -i ../patches/mipsel-2.8.patch
+RUN patch -su -p1 < ../patches/psx.patch
+
+RUN for dir in libiberty gcc; do \
+    cd /work/gcc-${VERSION}/${dir}; \
+    ./configure \
+        --target=mips-linux-gnu \
+        --prefix=/opt/cross \
+        --with-endian-little \
+        --with-gnu-as \
+        --disable-gprof \
+        --disable-gdb \
+        --disable-werror \
+        --host=i386-pc-linux \
+        --build=i386-pc-linux; \
+    done
+
+RUN make -C libiberty/ CFLAGS="-std=gnu89 -m32 -static"
+RUN make -C gcc/ --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
+
+COPY tests /work/tests
+RUN ./gcc/cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./gcc/cc1 -quiet -O2 /work/tests/section_attribute.c
+
+RUN mv ./gcc/xgcc ./gcc/gcc
+RUN mkdir /build && cp ./gcc/cpp ./gcc/cc1 ./gcc/gcc ./gcc/cc1plus ./gcc/g++ /build/
+
+FROM scratch AS export
+COPY --from=build /build/* .

--- a/gcc-2.95.2-psx.Dockerfile
+++ b/gcc-2.95.2-psx.Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:focal as build
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential gcc gcc-multilib wget
+
+ENV VERSION=2.95.2
+ENV GNUPATH=gnu
+
+WORKDIR /work
+RUN wget https://ftp.gnu.org/${GNUPATH}/gcc/gcc-${VERSION}.tar.gz
+RUN tar xzf gcc-${VERSION}.tar.gz
+
+WORKDIR /work/gcc-${VERSION}/
+
+COPY patches /work/patches
+
+RUN sed -i -- 's/include <varargs.h>/include <stdarg.h>/g' **/*.c
+RUN patch -u -p1 include/obstack.h -i ../patches/obstack-${VERSION}.h.patch
+RUN patch -u -p1 gcc/config/mips/mips.h -i ../patches/mipsel-2.8.patch
+RUN patch -su -p1 < ../patches/psx.patch
+
+RUN for dir in libiberty gcc; do \
+    cd /work/gcc-${VERSION}/${dir}; \
+    ./configure \
+        --target=mips-linux-gnu \
+        --prefix=/opt/cross \
+        --with-endian-little \
+        --with-gnu-as \
+        --disable-gprof \
+        --disable-gdb \
+        --disable-werror \
+        --host=i386-pc-linux \
+        --build=i386-pc-linux; \
+    done
+
+RUN make -C libiberty/ CFLAGS="-std=gnu89 -m32 -static"
+RUN make -C gcc/ --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -static"
+
+COPY tests /work/tests
+RUN ./gcc/cc1 -mel -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
+RUN ./gcc/cc1 -quiet -O2 /work/tests/section_attribute.c
+
+RUN mv ./gcc/xgcc ./gcc/gcc
+RUN mkdir /build && cp ./gcc/cpp ./gcc/cc1 ./gcc/gcc ./gcc/cc1plus ./gcc/g++ /build/
+
+FROM scratch AS export
+COPY --from=build /build/* .


### PR DESCRIPTION
On decomp.me we have PSYQ GCCs for:
- 2.6.0
- 2.7.2
- 2.8.0
- 2.91.66
- 2.95.2

This PR adds `-psx` flavours for these GCC versions so that we can tidy up decomp.me by removing the 'vanilla' ones.