### PR TITLE
Add native macOS build scripts (2.7.2-psx, 2.7.2-cdk, 2.8.1-psx)

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,45 @@
+name: Compile GCC (macOS)
+on:
+  push:
+    tags: '*'
+    branches: [master]
+    paths-ignore:
+      - README.md
+  pull_request:
+    branches: [master]
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 2.7.2-psx
+          - 2.7.2-cdk
+          - 2.8.1-psx
+    name: Build GCC ${{ matrix.version }} (macOS)
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          # byacc is required for gcc-2.7.2-cdk
+          brew install byacc
+      - name: Build GCC
+        run: VERSION=${{ matrix.version }} PLATFORM=macos make
+      - name: Create release archive
+        shell: bash
+        run: |
+          cd build-gcc-${{ matrix.version }}
+          tar -czvf ../gcc-${{ matrix.version }}-macos.tar.gz *
+      - name: Create artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gcc-${{ matrix.version }}-macos
+          path: gcc-${{ matrix.version }}-macos.tar.gz
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            gcc-${{ matrix.version }}-macos.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
+PLATFORM ?= linux
+
 all: check-version
+ifeq ($(PLATFORM),macos)
+	bash gcc-$(VERSION)-macos.sh
+else
 	docker build -f gcc-$(VERSION).Dockerfile --target export --output build-gcc-$(VERSION) .
+endif
 
 clean:
 	rm -rf build-gcc-*/
@@ -8,8 +14,14 @@ check-version:
 ifndef VERSION
 	$(error You must specify a VERSION e.g. `make VERSION=2.8.1`)
 endif
+ifeq ($(PLATFORM),macos)
+ifeq ($(wildcard gcc-$(VERSION)-macos.sh),)
+	$(error Building GCC $(VERSION) for macOS is not currently supported)
+endif
+else
 ifeq ($(wildcard gcc-$(VERSION).Dockerfile),)
 	$(error Building GCC $(VERSION) is not currently supported)
+endif
 endif
 
 .PHONY: all check-version

--- a/gcc-2.7.2-cdk-macos.sh
+++ b/gcc-2.7.2-cdk-macos.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Build gcc-2.7.2-cdk natively on macOS (x86_64 and aarch64).
+# Produces a Mach-O cc1 binary targeting mips-sony-psx.
+#
+# Requires: byacc  (install via Homebrew: brew install byacc)
+set -e
+
+if ! command -v byacc >/dev/null 2>&1; then
+    echo "Error: byacc is required. Install it with: brew install byacc" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PATCHES="$SCRIPT_DIR/patches"
+OUTDIR="$SCRIPT_DIR/build-gcc-2.7.2-cdk"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "Building gcc-2.7.2-cdk for macOS in $WORKDIR"
+
+cd "$WORKDIR"
+curl -fL "https://github.com/decompals/old-gcc/releases/download/0.14/b18.tar.gz" | tar xz
+cd cdk-gcc-b18
+
+# Apply the same patches as the Linux Dockerfile
+patch -u -p1 Makefile.in        -i "$PATCHES/Makefile-2.7.2-cdk.in.patch"
+patch -u -p1 obstack.h          -i "$PATCHES/obstack-2.7.2-cdk.h.patch"
+patch -u -p1 config/mips/mips.h -i "$PATCHES/mipsel-2.7-cdk.patch"
+patch -su -p1                   <  "$PATCHES/psx-2.7.2-cdk.patch"
+
+# macOS: replace config.guess/config.sub with modern versions that know
+# about aarch64-apple-darwin, then add psx* to the OS list.
+chmod +w config.guess config.sub
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess" -o config.guess
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"   -o config.sub
+chmod +x config.guess config.sub
+python3 -c "
+s = open('config.sub').read()
+s = s.replace('| hiux* | abug | nacl*', '| psx* \\\\\n\t     | hiux* | abug | nacl*', 1)
+open('config.sub', 'w').write(s)
+"
+
+# Add xm-darwin.h and teach configure about *-apple-darwin* hosts.
+cp "$PATCHES/xm-darwin.h" config/
+chmod +w configure
+python3 -c "
+s = open('configure').read()
+insert = '\t*-apple-darwin*)\n\t\txm_file=xm-darwin.h\n\t\tfixincludes=Makefile.in\n\t\t;;\n'
+s = s.replace('\t*)\n\t\techo \"Configuration \$machine not supported\"',
+              insert + '\t*)\n\t\techo \"Configuration \$machine not supported\"', 1)
+open('configure', 'w').write(s)
+"
+
+./configure \
+    --target=mips-sony-psx \
+    --prefix=/opt/cross \
+    --with-endian-little \
+    --with-gnu-as \
+    --disable-gprof \
+    --disable-gdb \
+    --disable-werror
+
+# Compile the __eprintf stub — this symbol was removed from macOS SDKs
+# after 10.14 but is referenced by the exception-handling code.
+cc -std=gnu89 -c "$PATCHES/eprintf-darwin.c" -o eprintf-darwin.o
+
+# Build single-threaded: parallel yacc invocations race on y.tab.h,
+# causing bi-parser.h to be generated with the wrong grammar.
+make cc1 \
+    CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration" \
+    LDFLAGS="eprintf-darwin.o"
+
+# Run the same tests as the Dockerfile
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
+grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
+
+mkdir -p "$OUTDIR"
+cp cc1 "$OUTDIR/cc1"
+echo "Done — $OUTDIR/cc1 ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"

--- a/gcc-2.7.2-cdk-macos.sh
+++ b/gcc-2.7.2-cdk-macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build gcc-2.7.2-cdk natively on macOS (x86_64 and aarch64).
-# Produces a Mach-O cc1 binary targeting mips-sony-psx.
+# Produces Mach-O cc1 and companion binaries targeting mips-sony-psx.
 #
 # Requires: byacc  (install via Homebrew: brew install byacc)
 set -e
@@ -18,11 +18,20 @@ trap 'rm -rf "$WORKDIR"' EXIT
 
 echo "Building gcc-2.7.2-cdk for macOS in $WORKDIR"
 
+# Ensure we use the system compiler and tools, not any cross-compiler wrappers
+# that may be in PATH (e.g. from a nix shell).
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+unset CC CXX
+
 cd "$WORKDIR"
 curl -fL "https://github.com/decompals/old-gcc/releases/download/0.14/b18.tar.gz" | tar xz
 cd cdk-gcc-b18
 
 # Apply the same patches as the Linux Dockerfile
+# macOS SDKs declare sys_nerr as 'const int'; fix the conflicting declarations.
+for f in gcc.c cp/g++.c; do
+    [ -f "$f" ] && sed -i '' 's/^extern int sys_nerr;/extern const int sys_nerr;/' "$f"
+done
 patch -u -p1 Makefile.in        -i "$PATCHES/Makefile-2.7.2-cdk.in.patch"
 patch -u -p1 obstack.h          -i "$PATCHES/obstack-2.7.2-cdk.h.patch"
 patch -u -p1 config/mips/mips.h -i "$PATCHES/mipsel-2.7-cdk.patch"
@@ -30,26 +39,24 @@ patch -su -p1                   <  "$PATCHES/psx-2.7.2-cdk.patch"
 
 # macOS: replace config.guess/config.sub with modern versions that know
 # about aarch64-apple-darwin, then add psx* to the OS list.
+# Pinned to specific commits for reproducibility.
 chmod +w config.guess config.sub
-curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess" -o config.guess
-curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"   -o config.sub
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/74af13c174714dd3b9f1ded4b39955f003c16361/config.guess" -o config.guess
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/6fad101f3063d722e3348d07dc93cf737f8709e4/config.sub"   -o config.sub
 chmod +x config.guess config.sub
-python3 -c "
-s = open('config.sub').read()
-s = s.replace('| hiux* | abug | nacl*', '| psx* \\\\\n\t     | hiux* | abug | nacl*', 1)
-open('config.sub', 'w').write(s)
-"
+sed -i '' 's/| hiux\* | abug | nacl\*/| psx* \\\
+'"$(printf '\t')"'     | hiux* | abug | nacl*/' config.sub
 
 # Add xm-darwin.h and teach configure about *-apple-darwin* hosts.
 cp "$PATCHES/xm-darwin.h" config/
 chmod +w configure
-python3 -c "
-s = open('configure').read()
-insert = '\t*-apple-darwin*)\n\t\txm_file=xm-darwin.h\n\t\tfixincludes=Makefile.in\n\t\t;;\n'
-s = s.replace('\t*)\n\t\techo \"Configuration \$machine not supported\"',
-              insert + '\t*)\n\t\techo \"Configuration \$machine not supported\"', 1)
-open('configure', 'w').write(s)
-"
+awk '/^\t\*\)$/ { buf=$0; next }
+     buf != "" { if (!done && /echo.*Configuration.*not supported/) {
+       print "\t*-apple-darwin*)"; print "\t\txm_file=xm-darwin.h"
+       print "\t\tfixincludes=Makefile.in"; print "\t\t;;"; done=1 }
+       print buf; buf="" } { print }' configure > configure.tmp
+mv configure.tmp configure
+chmod +x configure
 
 ./configure \
     --target=mips-sony-psx \
@@ -62,13 +69,14 @@ open('configure', 'w').write(s)
 
 # Compile the __eprintf stub — this symbol was removed from macOS SDKs
 # after 10.14 but is referenced by the exception-handling code.
-cc -std=gnu89 -c "$PATCHES/eprintf-darwin.c" -o eprintf-darwin.o
+EPRINTF_OBJ="$PWD/eprintf-darwin.o"
+cc -std=gnu89 -c "$PATCHES/eprintf-darwin.c" -o "$EPRINTF_OBJ"
 
 # Build single-threaded: parallel yacc invocations race on y.tab.h,
 # causing bi-parser.h to be generated with the wrong grammar.
-make cc1 \
-    CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration" \
-    LDFLAGS="eprintf-darwin.o"
+make cpp cc1 xgcc cc1plus g++ \
+    CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration -Wno-return-mismatch" \
+    LDFLAGS="$EPRINTF_OBJ"
 
 # Run the same tests as the Dockerfile
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
@@ -76,5 +84,6 @@ grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
 
 mkdir -p "$OUTDIR"
-cp cc1 "$OUTDIR/cc1"
-echo "Done — $OUTDIR/cc1 ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"
+cp cpp cc1 xgcc cc1plus g++ "$OUTDIR/"
+mv "$OUTDIR/xgcc" "$OUTDIR/gcc"
+echo "Done — $OUTDIR/ ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"

--- a/gcc-2.7.2-psx-macos.sh
+++ b/gcc-2.7.2-psx-macos.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Build gcc-2.7.2-psx natively on macOS (x86_64 and aarch64).
+# Produces a Mach-O cc1 binary targeting mips-sony-psx.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PATCHES="$SCRIPT_DIR/patches"
+OUTDIR="$SCRIPT_DIR/build-gcc-2.7.2-psx"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "Building gcc-2.7.2-psx for macOS in $WORKDIR"
+
+cd "$WORKDIR"
+curl -fL "https://ftp.gnu.org/old-gnu/gcc/gcc-2.7.2.tar.gz" | tar xz
+cd gcc-2.7.2
+
+# Apply the same patches as the Linux Dockerfile
+python3 -c "
+import glob, os, stat
+for f in glob.glob('*.c'):
+    s = open(f).read()
+    s2 = s.replace('include <varargs.h>', 'include <stdarg.h>')
+    if s2 != s:
+        os.chmod(f, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        open(f, 'w').write(s2)
+"
+patch -u -p1 obstack.h      -i "$PATCHES/obstack-2.7.2.h.patch"
+patch -u -p1 configure      -i "$PATCHES/configure.patch"
+patch -u -p1 config/mips/mips.h -i "$PATCHES/mipsel-2.7.patch"
+patch -su -p1               <  "$PATCHES/psx-2.5.7.patch"
+
+# macOS: replace config.guess/config.sub with modern versions that know
+# about aarch64-apple-darwin, then add psx* to the OS list.
+chmod +w config.guess config.sub
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess" -o config.guess
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"   -o config.sub
+chmod +x config.guess config.sub
+python3 -c "
+s = open('config.sub').read()
+s = s.replace('| hiux* | abug | nacl*', '| psx* \\\\\n\t     | hiux* | abug | nacl*', 1)
+open('config.sub', 'w').write(s)
+"
+
+# Add xm-darwin.h and teach configure about *-apple-darwin* hosts.
+cp "$PATCHES/xm-darwin.h" config/
+chmod +w configure
+python3 -c "
+s = open('configure').read()
+insert = '\t*-apple-darwin*)\n\t\txm_file=xm-darwin.h\n\t\tfixincludes=Makefile.in\n\t\t;;\n'
+s = s.replace('\t*)\n\t\techo \"Configuration \$machine not supported\"',
+              insert + '\t*)\n\t\techo \"Configuration \$machine not supported\"', 1)
+open('configure', 'w').write(s)
+"
+
+./configure \
+    --target=mips-sony-psx \
+    --prefix=/opt/cross \
+    --with-endian-little \
+    --with-gnu-as \
+    --disable-gprof \
+    --disable-gdb \
+    --disable-werror
+
+make --jobs "$(sysctl -n hw.ncpu)" cc1 \
+    CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration"
+
+# Run the same tests as the Dockerfile
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
+grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
+./cc1 -quiet -help </dev/null 2>&1 | grep -- -msoft-float
+
+mkdir -p "$OUTDIR"
+cp cc1 "$OUTDIR/cc1"
+echo "Done — $OUTDIR/cc1 ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"

--- a/gcc-2.7.2-psx-macos.sh
+++ b/gcc-2.7.2-psx-macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build gcc-2.7.2-psx natively on macOS (x86_64 and aarch64).
-# Produces a Mach-O cc1 binary targeting mips-sony-psx.
+# Produces Mach-O cc1 and companion binaries targeting mips-sony-psx.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -11,20 +11,24 @@ trap 'rm -rf "$WORKDIR"' EXIT
 
 echo "Building gcc-2.7.2-psx for macOS in $WORKDIR"
 
+# Ensure we use the system compiler and tools, not any cross-compiler wrappers
+# that may be in PATH (e.g. from a nix shell).
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+unset CC CXX
+
 cd "$WORKDIR"
 curl -fL "https://ftp.gnu.org/old-gnu/gcc/gcc-2.7.2.tar.gz" | tar xz
 cd gcc-2.7.2
 
 # Apply the same patches as the Linux Dockerfile
-python3 -c "
-import glob, os, stat
-for f in glob.glob('*.c'):
-    s = open(f).read()
-    s2 = s.replace('include <varargs.h>', 'include <stdarg.h>')
-    if s2 != s:
-        os.chmod(f, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-        open(f, 'w').write(s2)
-"
+# Replace varargs.h with stdarg.h; some files are read-only from the tarball.
+grep -rl 'include <varargs\.h>' *.c | xargs chmod u+w
+sed -i '' 's/include <varargs\.h>/include <stdarg\.h>/g' *.c
+# macOS SDKs declare sys_nerr as 'const int'; fix the conflicting declarations.
+for f in gcc.c cp/g++.c; do
+    [ -f "$f" ] && sed -i '' 's/^extern int sys_nerr;/extern const int sys_nerr;/' "$f"
+done
+
 patch -u -p1 obstack.h      -i "$PATCHES/obstack-2.7.2.h.patch"
 patch -u -p1 configure      -i "$PATCHES/configure.patch"
 patch -u -p1 config/mips/mips.h -i "$PATCHES/mipsel-2.7.patch"
@@ -32,26 +36,24 @@ patch -su -p1               <  "$PATCHES/psx-2.5.7.patch"
 
 # macOS: replace config.guess/config.sub with modern versions that know
 # about aarch64-apple-darwin, then add psx* to the OS list.
+# Pinned to specific commits for reproducibility.
 chmod +w config.guess config.sub
-curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess" -o config.guess
-curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"   -o config.sub
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/74af13c174714dd3b9f1ded4b39955f003c16361/config.guess" -o config.guess
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/6fad101f3063d722e3348d07dc93cf737f8709e4/config.sub"   -o config.sub
 chmod +x config.guess config.sub
-python3 -c "
-s = open('config.sub').read()
-s = s.replace('| hiux* | abug | nacl*', '| psx* \\\\\n\t     | hiux* | abug | nacl*', 1)
-open('config.sub', 'w').write(s)
-"
+sed -i '' 's/| hiux\* | abug | nacl\*/| psx* \\\
+'"$(printf '\t')"'     | hiux* | abug | nacl*/' config.sub
 
 # Add xm-darwin.h and teach configure about *-apple-darwin* hosts.
 cp "$PATCHES/xm-darwin.h" config/
 chmod +w configure
-python3 -c "
-s = open('configure').read()
-insert = '\t*-apple-darwin*)\n\t\txm_file=xm-darwin.h\n\t\tfixincludes=Makefile.in\n\t\t;;\n'
-s = s.replace('\t*)\n\t\techo \"Configuration \$machine not supported\"',
-              insert + '\t*)\n\t\techo \"Configuration \$machine not supported\"', 1)
-open('configure', 'w').write(s)
-"
+awk '/^\t\*\)$/ { buf=$0; next }
+     buf != "" { if (!done && /echo.*Configuration.*not supported/) {
+       print "\t*-apple-darwin*)"; print "\t\txm_file=xm-darwin.h"
+       print "\t\tfixincludes=Makefile.in"; print "\t\t;;"; done=1 }
+       print buf; buf="" } { print }' configure > configure.tmp
+mv configure.tmp configure
+chmod +x configure
 
 ./configure \
     --target=mips-sony-psx \
@@ -62,8 +64,8 @@ open('configure', 'w').write(s)
     --disable-gdb \
     --disable-werror
 
-make --jobs "$(sysctl -n hw.ncpu)" cc1 \
-    CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration"
+make --jobs "$(sysctl -n hw.ncpu)" cpp cc1 xgcc cc1plus g++ \
+    CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration -Wno-return-mismatch"
 
 # Run the same tests as the Dockerfile
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
@@ -72,5 +74,6 @@ grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -quiet -help </dev/null 2>&1 | grep -- -msoft-float
 
 mkdir -p "$OUTDIR"
-cp cc1 "$OUTDIR/cc1"
-echo "Done — $OUTDIR/cc1 ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"
+cp cpp cc1 xgcc cc1plus g++ "$OUTDIR/"
+mv "$OUTDIR/xgcc" "$OUTDIR/gcc"
+echo "Done — $OUTDIR/ ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"

--- a/gcc-2.8.1-psx-macos.sh
+++ b/gcc-2.8.1-psx-macos.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Build gcc-2.8.1-psx natively on macOS (x86_64 and aarch64).
+# Produces a Mach-O cc1 binary targeting mips-sony-psx.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PATCHES="$SCRIPT_DIR/patches"
+OUTDIR="$SCRIPT_DIR/build-gcc-2.8.1-psx"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "Building gcc-2.8.1-psx for macOS in $WORKDIR"
+
+# Ensure we use the system compiler, not any cross-compiler wrappers that
+# may be in PATH (e.g. from a nix shell).
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+unset CC CXX
+
+cd "$WORKDIR"
+curl -fL "https://mirrors.kernel.org/gnu/gcc/gcc-2.8.1.tar.gz" | tar xz
+cd gcc-2.8.1
+
+# Apply the same patches as the Linux Dockerfile
+python3 -c "
+import glob, os, stat
+for f in glob.glob('*.c'):
+    s = open(f).read()
+    s2 = s.replace('include <varargs.h>', 'include <stdarg.h>')
+    if s2 != s:
+        os.chmod(f, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        open(f, 'w').write(s2)
+"
+patch -u -p1 obstack.h          -i "$PATCHES/obstack-2.8.1.h.patch"
+patch -u -p1 config/mips/mips.h -i "$PATCHES/mips.patch"
+patch -su -p1                   <  "$PATCHES/psx.patch"
+
+# macOS: replace config.guess/config.sub with modern versions that know
+# about aarch64-apple-darwin, then add psx* to the OS list.
+chmod +w config.guess config.sub
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess" -o config.guess
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"   -o config.sub
+chmod +x config.guess config.sub
+python3 -c "
+s = open('config.sub').read()
+s = s.replace('| hiux* | abug | nacl*', '| psx* \\\\\n\t     | hiux* | abug | nacl*', 1)
+open('config.sub', 'w').write(s)
+"
+
+# Add xm-darwin.h and teach configure about *-apple-darwin* hosts.
+cp "$PATCHES/xm-darwin.h" config/
+chmod +w configure
+python3 -c "
+s = open('configure').read()
+insert = '\t*-apple-darwin*)\n\t\txm_file=xm-darwin.h\n\t\tfixincludes=Makefile.in\n\t\t;;\n'
+s = s.replace('\t*)\n\t\techo \"Configuration \$machine not supported\"',
+              insert + '\t*)\n\t\techo \"Configuration \$machine not supported\"', 1)
+open('configure', 'w').write(s)
+"
+
+# Explicitly pass --host/--build so configure uses a single-arg config.sub
+# call (which modern config.sub accepts), rather than its multi-arg form.
+# Export CFLAGS so configure's compiler test (main(){return(0);}) passes under
+# modern clang, which rejects implicit int without -std=gnu89.
+DARWIN_HOST="$(uname -m)-apple-darwin"
+export CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration -Wno-return-mismatch"
+./configure \
+    --target=mips-sony-psx \
+    --host="$DARWIN_HOST" \
+    --build="$DARWIN_HOST" \
+    --prefix=/opt/cross \
+    --with-endian-little \
+    --with-gnu-as \
+    --disable-gprof \
+    --disable-gdb \
+    --disable-werror
+
+# insn-config.h is generated during the build but referenced early; touch
+# it to prevent spurious missing-file errors on some make versions.
+touch insn-config.h
+
+make --jobs "$(sysctl -n hw.ncpu)" cc1 \
+    CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration -Wno-return-mismatch"
+
+# Run the same tests as the Dockerfile
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
+grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
+./cc1 -version </dev/null 2>&1 | grep -- -msoft-float
+./cc1 -version </dev/null 2>&1 | grep -- -msplit-addresses
+./cc1 -version </dev/null 2>&1 | grep -- -mgpopt
+
+mkdir -p "$OUTDIR"
+cp cc1 "$OUTDIR/cc1"
+echo "Done — $OUTDIR/cc1 ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"

--- a/gcc-2.8.1-psx-macos.sh
+++ b/gcc-2.8.1-psx-macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build gcc-2.8.1-psx natively on macOS (x86_64 and aarch64).
-# Produces a Mach-O cc1 binary targeting mips-sony-psx.
+# Produces Mach-O cc1 and companion binaries targeting mips-sony-psx.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -21,41 +21,38 @@ curl -fL "https://mirrors.kernel.org/gnu/gcc/gcc-2.8.1.tar.gz" | tar xz
 cd gcc-2.8.1
 
 # Apply the same patches as the Linux Dockerfile
-python3 -c "
-import glob, os, stat
-for f in glob.glob('*.c'):
-    s = open(f).read()
-    s2 = s.replace('include <varargs.h>', 'include <stdarg.h>')
-    if s2 != s:
-        os.chmod(f, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-        open(f, 'w').write(s2)
-"
+# Replace varargs.h with stdarg.h; some files are read-only from the tarball.
+grep -rl 'include <varargs\.h>' *.c | xargs chmod u+w
+sed -i '' 's/include <varargs\.h>/include <stdarg\.h>/g' *.c
+# macOS SDKs declare sys_nerr as 'const int'; fix the conflicting declarations.
+for f in gcc.c cp/g++.c; do
+    [ -f "$f" ] && sed -i '' 's/^extern int sys_nerr;/extern const int sys_nerr;/' "$f"
+done
+
 patch -u -p1 obstack.h          -i "$PATCHES/obstack-2.8.1.h.patch"
 patch -u -p1 config/mips/mips.h -i "$PATCHES/mips.patch"
 patch -su -p1                   <  "$PATCHES/psx.patch"
 
 # macOS: replace config.guess/config.sub with modern versions that know
 # about aarch64-apple-darwin, then add psx* to the OS list.
+# Pinned to specific commits for reproducibility.
 chmod +w config.guess config.sub
-curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess" -o config.guess
-curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.sub"   -o config.sub
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/74af13c174714dd3b9f1ded4b39955f003c16361/config.guess" -o config.guess
+curl -fsL "https://raw.githubusercontent.com/gcc-mirror/gcc/6fad101f3063d722e3348d07dc93cf737f8709e4/config.sub"   -o config.sub
 chmod +x config.guess config.sub
-python3 -c "
-s = open('config.sub').read()
-s = s.replace('| hiux* | abug | nacl*', '| psx* \\\\\n\t     | hiux* | abug | nacl*', 1)
-open('config.sub', 'w').write(s)
-"
+sed -i '' 's/| hiux\* | abug | nacl\*/| psx* \\\
+'"$(printf '\t')"'     | hiux* | abug | nacl*/' config.sub
 
 # Add xm-darwin.h and teach configure about *-apple-darwin* hosts.
 cp "$PATCHES/xm-darwin.h" config/
 chmod +w configure
-python3 -c "
-s = open('configure').read()
-insert = '\t*-apple-darwin*)\n\t\txm_file=xm-darwin.h\n\t\tfixincludes=Makefile.in\n\t\t;;\n'
-s = s.replace('\t*)\n\t\techo \"Configuration \$machine not supported\"',
-              insert + '\t*)\n\t\techo \"Configuration \$machine not supported\"', 1)
-open('configure', 'w').write(s)
-"
+awk '/^\t\*\)$/ { buf=$0; next }
+     buf != "" { if (!done && /echo.*Configuration.*not supported/) {
+       print "\t*-apple-darwin*)"; print "\t\txm_file=xm-darwin.h"
+       print "\t\tfixincludes=Makefile.in"; print "\t\t;;"; done=1 }
+       print buf; buf="" } { print }' configure > configure.tmp
+mv configure.tmp configure
+chmod +x configure
 
 # Explicitly pass --host/--build so configure uses a single-arg config.sub
 # call (which modern config.sub accepts), rather than its multi-arg form.
@@ -78,7 +75,7 @@ export CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declarat
 # it to prevent spurious missing-file errors on some make versions.
 touch insn-config.h
 
-make --jobs "$(sysctl -n hw.ncpu)" cc1 \
+make --jobs "$(sysctl -n hw.ncpu)" cpp cc1 xgcc cc1plus g++ \
     CFLAGS="-std=gnu89 -w -Wno-int-conversion -Wno-implicit-function-declaration -Wno-return-mismatch"
 
 # Run the same tests as the Dockerfile
@@ -90,5 +87,6 @@ grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -version </dev/null 2>&1 | grep -- -mgpopt
 
 mkdir -p "$OUTDIR"
-cp cc1 "$OUTDIR/cc1"
-echo "Done — $OUTDIR/cc1 ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"
+cp cpp cc1 xgcc cc1plus g++ "$OUTDIR/"
+mv "$OUTDIR/xgcc" "$OUTDIR/gcc"
+echo "Done — $OUTDIR/ ($(file "$OUTDIR/cc1" | cut -d: -f2 | xargs))"

--- a/patches/eprintf-darwin.c
+++ b/patches/eprintf-darwin.c
@@ -1,0 +1,11 @@
+/* Stub for __eprintf, removed from macOS SDKs after 10.14.
+   Required by gcc-2.7.2-cdk's exception-handling code.  */
+#include <stdio.h>
+#include <stdlib.h>
+
+void
+__eprintf (const char *fmt, const char *file, unsigned line, const char *expr)
+{
+  fprintf (stderr, fmt, file, line, expr);
+  abort ();
+}

--- a/patches/eprintf-darwin.c
+++ b/patches/eprintf-darwin.c
@@ -3,7 +3,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void
+/* weak: if another object (e.g. tree.o in cdk) also defines __eprintf,
+   that strong definition takes precedence and no duplicate-symbol error occurs. */
+__attribute__((weak)) void
 __eprintf (const char *fmt, const char *file, unsigned line, const char *expr)
 {
   fprintf (stderr, fmt, file, line, expr);

--- a/patches/xm-darwin.h
+++ b/patches/xm-darwin.h
@@ -1,0 +1,25 @@
+/* Host machine description for GCC running on macOS (Darwin).
+   Works for both x86_64 and aarch64 (Apple Silicon).
+
+   macOS uses the LP64 model: int is 32-bit, long and pointers are 64-bit.  */
+
+#define HOST_BITS_PER_CHAR    8
+#define HOST_BITS_PER_SHORT  16
+#define HOST_BITS_PER_INT    32
+#define HOST_BITS_PER_LONG   64
+#define HOST_BITS_PER_LONGLONG 64
+
+#define FALSE 0
+#define TRUE  1
+
+#define SUCCESS_EXIT_CODE 0
+#define FATAL_EXIT_CODE 33
+
+#define HAVE_VPRINTF
+#define HAVE_STRERROR
+#define POSIX
+
+/* macOS provides bcopy/bcmp/bzero via <string.h>.  */
+#define BSTRING
+
+#include "tm.h"


### PR DESCRIPTION
Closes #33.

Following @mkst's suggestion in #33 to go with **option 2** (separate scripts, similar to existing Dockerfiles), this PR adds native macOS build scripts that produce Mach-O arm64/x86_64 `cc1` binaries without requiring Docker.

## What's included

- `gcc-2.7.2-psx-macos.sh`
- `gcc-2.7.2-cdk-macos.sh`
- `gcc-2.8.1-psx-macos.sh`
- `patches/xm-darwin.h` — LP64 host descriptor for macOS Darwin
- `patches/eprintf-darwin.c` — `__eprintf` stub (removed from macOS SDKs post-10.14, needed by 2.7.2-cdk)
- `Makefile` — `PLATFORM=macos` support (`make VERSION=2.8.1-psx PLATFORM=macos`)
- `.github/workflows/build-macos.yml` — CI on `macos-latest`, publishes `gcc-VERSION-macos.tar.gz` to releases on tags

## macOS-specific patches applied by the scripts

1. **config.guess/config.sub** — replaced with modern versions (knows about aarch64-apple-darwin); `psx*` added to config.sub OS list
2. **configure** — `*-apple-darwin*` case added to host machine selection, pointing to new `xm-darwin.h`
3. **xm-darwin.h** — host descriptor for LP64 macOS (int=32-bit, long=64-bit); defines `FALSE`, `TRUE`, `HAVE_VPRINTF`, `HAVE_STRERROR`, `POSIX`, `BSTRING`
4. **configure invocation** — `--host`/`--build` passed explicitly (avoids multi-arg `config.sub` call that modern config.sub rejects); CFLAGS exported so the configure compiler test (`main(){}`) passes modern clang
5. **2.7.2-cdk specific** — requires `byacc`, single-threaded build (parallel `yacc` invocations race on `y.tab.h`), `__eprintf` stub linked in via `LDFLAGS`
6. **2.8.1-psx specific** — `touch insn-config.h` before build, `unset CC CXX`, system PATH prepended

All three scripts have been tested on macOS 15 (Apple Silicon, arm64) and produce binaries that pass the same test suite as the Dockerfiles.

This is motivated by the need to build [ser-pounce/rood-reverse](https://github.com/ser-pounce/rood-reverse) natively on macOS — see ser-pounce/rood-reverse#9 for context.