### PR TITLE
xm-darwin: force 32-bit HOST_WIDE_INT to match Linux i386 reference

### DIFF
--- a/gcc-2.7.2-cdk-macos.sh
+++ b/gcc-2.7.2-cdk-macos.sh
@@ -82,7 +82,6 @@ make cpp cc1 xgcc cc1plus g++ \
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
 grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
-# Regression test for HOST_WIDE_INT width — see tests/host_wide_int.c.
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/host_wide_int.c" -o host_wide_int.s
 grep -E '# 0x80000000$' host_wide_int.s
 

--- a/gcc-2.7.2-cdk-macos.sh
+++ b/gcc-2.7.2-cdk-macos.sh
@@ -82,6 +82,9 @@ make cpp cc1 xgcc cc1plus g++ \
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
 grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
+# Regression test for HOST_WIDE_INT width — see tests/host_wide_int.c.
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/host_wide_int.c" -o host_wide_int.s
+grep -E '# 0x80000000$' host_wide_int.s
 
 mkdir -p "$OUTDIR"
 cp cpp cc1 xgcc cc1plus g++ "$OUTDIR/"

--- a/gcc-2.7.2-cdk.Dockerfile
+++ b/gcc-2.7.2-cdk.Dockerfile
@@ -31,6 +31,11 @@ RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -stati
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
 RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
+# Regression test for HOST_WIDE_INT width: cc1 prints constants at HOST_WIDE_INT
+# width. The i386 reference build (32-bit) prints `# 0x80000000`; a 64-bit-host
+# build prints `# 0xffffffff80000000`, indicating long has leaked into cc1's
+# internal integer arithmetic and machine code will diverge from the reference.
+RUN ./cc1 -quiet -O2 /work/tests/host_wide_int.c && grep -E '# 0x80000000$' /work/tests/host_wide_int.s
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.7.2-cdk.Dockerfile
+++ b/gcc-2.7.2-cdk.Dockerfile
@@ -31,10 +31,6 @@ RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -stati
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
 RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
-# Regression test for HOST_WIDE_INT width: cc1 prints constants at HOST_WIDE_INT
-# width. The i386 reference build (32-bit) prints `# 0x80000000`; a 64-bit-host
-# build prints `# 0xffffffff80000000`, indicating long has leaked into cc1's
-# internal integer arithmetic and machine code will diverge from the reference.
 RUN ./cc1 -quiet -O2 /work/tests/host_wide_int.c && grep -E '# 0x80000000$' /work/tests/host_wide_int.s
 
 RUN mv xgcc gcc

--- a/gcc-2.7.2-psx-macos.sh
+++ b/gcc-2.7.2-psx-macos.sh
@@ -71,7 +71,6 @@ make --jobs "$(sysctl -n hw.ncpu)" cpp cc1 xgcc cc1plus g++ \
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
 grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
-# Regression test for HOST_WIDE_INT width — see tests/host_wide_int.c.
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/host_wide_int.c" -o host_wide_int.s
 grep -E '# 0x80000000$' host_wide_int.s
 ./cc1 -quiet -help</dev/null 2>&1 | grep -- -msoft-float

--- a/gcc-2.7.2-psx-macos.sh
+++ b/gcc-2.7.2-psx-macos.sh
@@ -71,7 +71,10 @@ make --jobs "$(sysctl -n hw.ncpu)" cpp cc1 xgcc cc1plus g++ \
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
 grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
-./cc1 -quiet -help </dev/null 2>&1 | grep -- -msoft-float
+# Regression test for HOST_WIDE_INT width — see tests/host_wide_int.c.
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/host_wide_int.c" -o host_wide_int.s
+grep -E '# 0x80000000$' host_wide_int.s
+./cc1 -quiet -help</dev/null 2>&1 | grep -- -msoft-float
 
 mkdir -p "$OUTDIR"
 cp cpp cc1 xgcc cc1plus g++ "$OUTDIR/"

--- a/gcc-2.7.2-psx.Dockerfile
+++ b/gcc-2.7.2-psx.Dockerfile
@@ -37,7 +37,12 @@ RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -stati
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
 RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
-RUN ./cc1 -quiet -help </dev/null 2>&1 | grep -- -msoft-float
+# Regression test for HOST_WIDE_INT width: cc1 prints constants at HOST_WIDE_INT
+# width. The i386 reference build (32-bit) prints `# 0x80000000`; a 64-bit-host
+# build prints `# 0xffffffff80000000`, indicating long has leaked into cc1's
+# internal integer arithmetic and machine code will diverge from the reference.
+RUN ./cc1 -quiet -O2 /work/tests/host_wide_int.c && grep -E '# 0x80000000$' /work/tests/host_wide_int.s
+RUN ./cc1 -quiet -help</dev/null 2>&1 | grep -- -msoft-float
 
 RUN mv xgcc gcc
 RUN mkdir /build && cp cpp cc1 gcc cc1plus g++ /build/

--- a/gcc-2.7.2-psx.Dockerfile
+++ b/gcc-2.7.2-psx.Dockerfile
@@ -37,10 +37,6 @@ RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -stati
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
 RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
-# Regression test for HOST_WIDE_INT width: cc1 prints constants at HOST_WIDE_INT
-# width. The i386 reference build (32-bit) prints `# 0x80000000`; a 64-bit-host
-# build prints `# 0xffffffff80000000`, indicating long has leaked into cc1's
-# internal integer arithmetic and machine code will diverge from the reference.
 RUN ./cc1 -quiet -O2 /work/tests/host_wide_int.c && grep -E '# 0x80000000$' /work/tests/host_wide_int.s
 RUN ./cc1 -quiet -help</dev/null 2>&1 | grep -- -msoft-float
 

--- a/gcc-2.8.1-psx-macos.sh
+++ b/gcc-2.8.1-psx-macos.sh
@@ -82,7 +82,6 @@ make --jobs "$(sysctl -n hw.ncpu)" cpp cc1 xgcc cc1plus g++ \
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
 grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
-# Regression test for HOST_WIDE_INT width — see tests/host_wide_int.c.
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/host_wide_int.c" -o host_wide_int.s
 grep -E '# 0x80000000$' host_wide_int.s
 ./cc1 -version</dev/null 2>&1 | grep -- -msoft-float

--- a/gcc-2.8.1-psx-macos.sh
+++ b/gcc-2.8.1-psx-macos.sh
@@ -82,7 +82,10 @@ make --jobs "$(sysctl -n hw.ncpu)" cpp cc1 xgcc cc1plus g++ \
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/little_endian.c" -o little_endian.s
 grep -E 'lbu\s\$2,0\(\$4\)' little_endian.s
 ./cc1 -quiet -O2 "$SCRIPT_DIR/tests/section_attribute.c" -o /dev/null
-./cc1 -version </dev/null 2>&1 | grep -- -msoft-float
+# Regression test for HOST_WIDE_INT width — see tests/host_wide_int.c.
+./cc1 -quiet -O2 "$SCRIPT_DIR/tests/host_wide_int.c" -o host_wide_int.s
+grep -E '# 0x80000000$' host_wide_int.s
+./cc1 -version</dev/null 2>&1 | grep -- -msoft-float
 ./cc1 -version </dev/null 2>&1 | grep -- -msplit-addresses
 ./cc1 -version </dev/null 2>&1 | grep -- -mgpopt
 

--- a/gcc-2.8.1-psx.Dockerfile
+++ b/gcc-2.8.1-psx.Dockerfile
@@ -37,7 +37,12 @@ RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -stati
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
 RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
-RUN ./cc1 -version </dev/null 2>&1 | grep -- -msoft-float
+# Regression test for HOST_WIDE_INT width: cc1 prints constants at HOST_WIDE_INT
+# width. The i386 reference build (32-bit) prints `# 0x80000000`; a 64-bit-host
+# build prints `# 0xffffffff80000000`, indicating long has leaked into cc1's
+# internal integer arithmetic and machine code will diverge from the reference.
+RUN ./cc1 -quiet -O2 /work/tests/host_wide_int.c && grep -E '# 0x80000000$' /work/tests/host_wide_int.s
+RUN ./cc1 -version</dev/null 2>&1 | grep -- -msoft-float
 RUN ./cc1 -version </dev/null 2>&1 | grep -- -msplit-addresses
 RUN ./cc1 -version </dev/null 2>&1 | grep -- -mgpopt
 

--- a/gcc-2.8.1-psx.Dockerfile
+++ b/gcc-2.8.1-psx.Dockerfile
@@ -37,10 +37,6 @@ RUN make --jobs $(nproc) cpp cc1 xgcc cc1plus g++ CFLAGS="-std=gnu89 -m32 -stati
 COPY tests /work/tests
 RUN ./cc1 -quiet -O2 /work/tests/little_endian.c && grep -E 'lbu\s\$2,0\(\$4\)' /work/tests/little_endian.s
 RUN ./cc1 -quiet -O2 /work/tests/section_attribute.c
-# Regression test for HOST_WIDE_INT width: cc1 prints constants at HOST_WIDE_INT
-# width. The i386 reference build (32-bit) prints `# 0x80000000`; a 64-bit-host
-# build prints `# 0xffffffff80000000`, indicating long has leaked into cc1's
-# internal integer arithmetic and machine code will diverge from the reference.
 RUN ./cc1 -quiet -O2 /work/tests/host_wide_int.c && grep -E '# 0x80000000$' /work/tests/host_wide_int.s
 RUN ./cc1 -version</dev/null 2>&1 | grep -- -msoft-float
 RUN ./cc1 -version </dev/null 2>&1 | grep -- -msplit-addresses

--- a/patches/xm-darwin.h
+++ b/patches/xm-darwin.h
@@ -22,16 +22,6 @@
 /* macOS provides bcopy/bcmp/bzero via <string.h>.  */
 #define BSTRING
 
-/* Force 32-bit HOST_WIDE_INT to match the Linux i386 -m32 reference build.
-   Without this override, machmode.h derives HOST_WIDE_INT from `long`
-   (64-bit on darwin LP64), which changes cc1's internal integer-constant
-   arithmetic (constant folding, RTL constants, shift/sign-extend) vs the
-   reference Linux build. The result is non-bit-identical machine code for
-   the same input C — verified against rood-reverse where this caused 8
-   PRGs to fail `make check`.
-
-   cc1 remains a 64-bit Mach-O binary; only the target-constant width is
-   constrained, mirroring what the i386-host Linux cc1 does.  */
 #define HOST_BITS_PER_WIDE_INT 32
 #define HOST_WIDE_INT int
 

--- a/patches/xm-darwin.h
+++ b/patches/xm-darwin.h
@@ -22,4 +22,17 @@
 /* macOS provides bcopy/bcmp/bzero via <string.h>.  */
 #define BSTRING
 
+/* Force 32-bit HOST_WIDE_INT to match the Linux i386 -m32 reference build.
+   Without this override, machmode.h derives HOST_WIDE_INT from `long`
+   (64-bit on darwin LP64), which changes cc1's internal integer-constant
+   arithmetic (constant folding, RTL constants, shift/sign-extend) vs the
+   reference Linux build. The result is non-bit-identical machine code for
+   the same input C — verified against rood-reverse where this caused 8
+   PRGs to fail `make check`.
+
+   cc1 remains a 64-bit Mach-O binary; only the target-constant width is
+   constrained, mirroring what the i386-host Linux cc1 does.  */
+#define HOST_BITS_PER_WIDE_INT 32
+#define HOST_WIDE_INT int
+
 #include "tm.h"

--- a/tests/host_wide_int.c
+++ b/tests/host_wide_int.c
@@ -1,0 +1,3 @@
+unsigned int signbit_mask(void) {
+    return 1u << 31;
+}


### PR DESCRIPTION
## Problem

The macOS-native cc1 binaries (added in #34) produce non-bit-identical machine code vs the Linux i386 reference build for the same C input. Concrete repro: when used as the cc1 binary for [rood-reverse](https://github.com/ser-pounce/rood-reverse) (a PSX decompilation), 8 of the project's PRGs fail \`make check\`. Same C source, same maspsx/binutils chain, same preprocessor — only the cc1 binary differs.

For example, MENU8.PRG/88.o is 44 bytes shorter when compiled by the macOS cc1 vs the Linux cc1, and that drift cascades across sections downstream.

## Root cause

\`machmode.h:49-55\` derives \`HOST_WIDE_INT\` from \`long\`:

\`\`\`c
#if HOST_BITS_PER_LONG > HOST_BITS_PER_INT
#define HOST_BITS_PER_WIDE_INT HOST_BITS_PER_LONG
#define HOST_WIDE_INT long
#else
#define HOST_BITS_PER_WIDE_INT HOST_BITS_PER_INT
#define HOST_WIDE_INT int
#endif
\`\`\`

- Linux build: \`--host=i386-pc-linux\` + \`CFLAGS=\"-m32 -static\"\` → LONG=32, INT=32 → \`HOST_WIDE_INT = int\` (32-bit)
- macOS build: LP64 → LONG=64, INT=32 → \`HOST_WIDE_INT = long\` (64-bit)

cc1's internal integer-constant arithmetic (constant folding, RTL constants, shifts, sign-extension) all operate on \`HOST_WIDE_INT\`. With 64-bit width, intermediate values keep precision the source never asked for, propagating into different code generation in non-trivial ways.

## Fix

Override \`HOST_WIDE_INT\` to 32-bit in \`patches/xm-darwin.h\`. cc1 itself remains a 64-bit Mach-O binary; only target-constant width is constrained. Host pointer / \`size_t\` semantics are unaffected.

## Test

Adds \`tests/host_wide_int.c\` — compiles \`return 1u << 31;\` and greps for \`# 0x80000000$\` in the output. cc1 prints constants at \`HOST_WIDE_INT\` width:

- 32-bit (correct): \`li \$2,-2147483648 # 0x80000000\`
- 64-bit (broken): \`li \$2,-2147483648 # 0xffffffff80000000\`

The grep catches the divergence without needing bit-exact .o comparisons. Wired into all three \`*-macos.sh\` scripts and the corresponding Linux Dockerfiles for parity.

## Validation

With this patch applied:
- All three macOS cc1 binaries (2.7.2-psx, 2.7.2-cdk, 2.8.1-psx) pass the new test
- Existing \`little_endian\` / \`section_attribute\` / \`-msoft-float\` / etc. tests still pass
- rood-reverse \`make check\` goes from 8 PRG mismatches to ✔ all match on aarch64-darwin